### PR TITLE
Corregir el valor de la llave 'sueldo_completo' del ejemplo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Tu programa deberá recibir como input un JSON con esta estructura:
 ```
 
 
-En la respuesta deberás llenar la llave `sueldo_completo` con el monto correcto de cada jugador. 
+En la respuesta deberás llenar la llave `sueldo_completo` con el monto correcto de cada jugador: 
 
 ```json
 {
@@ -104,7 +104,7 @@ En la respuesta deberás llenar la llave `sueldo_completo` con el monto correcto
          "goles":9,
          "sueldo":30000,
          "bono":15000,
-         "sueldo_completo": 42450,
+         "sueldo_completo":42450,
          "equipo":"rojo"
       },
       ...

--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ En la respuesta deberás llenar la llave `sueldo_completo` con el monto correcto
          "goles":9,
          "sueldo":30000,
          "bono":15000,
-         "sueldo_completo": 14250,
+         "sueldo_completo": 42450,
          "equipo":"rojo"
-      }
+      },
+      ...
    ]
 }
 ```


### PR DESCRIPTION
Si 'sueldo_completo' es la suma del sueldo (que es fijo) y el bono (que es variable según los indicadores por jugador y equipo), el dato correcto de "El Rulo" con el JSON previo de ejemplo sería 42.450 que corresponden a 30.000 de sueldo, 6.750 del bono individual y 5.700 del bono de equipo (total bono: 12.450).